### PR TITLE
Perf: replace jq with jaq (rusty business)

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ In order to keep this clean, and being only an Eww configuration, my dotfiles ar
 ```bash
 paru --needed -S hyprland eww-wayland dunst libnotify libcanberra\
                  hyprpaper swayidle swaylock-effects-git neofetch duf\
-                 wl-clipboard cliphist pulsemixer light jq networkmanager\
+                 wl-clipboard cliphist pulsemixer light jaq networkmanager\
                  sound-theme-freedesktop
 ```
 

--- a/scripts/dockctl
+++ b/scripts/dockctl
@@ -4,10 +4,10 @@
 
 # Get required settings from config.json.
 readarray -t config <\
-  <(jq '.dock_app_path,
-        .dock_app_icon_path,
-        .dock_app_icon_size,
-        .terminal_cmd' "$PWD/config.json")
+  <(jaq '.dock_app_path,
+         .dock_app_icon_path,
+         .dock_app_icon_size,
+         .terminal_cmd' "$PWD/config.json")
 
 # Remove double quotes.
 app_path="${config[0]//\"}"

--- a/scripts/keyboardctl
+++ b/scripts/keyboardctl
@@ -4,7 +4,7 @@
 
 # This script is not used at the moment.
 : "$(hyprctl devices -j\
-  | jq '.keyboards?[0].active_keymap')"
+  | jaq '.keyboards?[0].active_keymap')"
 : "${_//\"}" && : "${_:0:2}"
 printf '%s' "${_^^}"
 

--- a/scripts/launcherctl
+++ b/scripts/launcherctl
@@ -4,9 +4,9 @@
 
 # Get required settings from config.json.
 readarray -t config <\
-  <(jq '.launcher_app_path,
-        .launcher_app_icon_path,
-        .terminal_cmd' "$PWD/config.json")
+  <(jaq '.launcher_app_path,
+         .launcher_app_icon_path,
+         .terminal_cmd' "$PWD/config.json")
 
 # Remove double quotes.
 app_path="${config[0]//\"}"

--- a/scripts/standbyctl
+++ b/scripts/standbyctl
@@ -4,8 +4,7 @@
 
 # Get required settings from config.json.
 readarray -t config <\
-  <(jq '.suspend_timeout, .sleep_timeout'\
-       "$PWD/config.json")
+  <(jaq '.suspend_timeout, .sleep_timeout' "$PWD/config.json")
 
 # Run swayidle with hyprctl (timeout from config.json).
 function standby_mode() {

--- a/scripts/updatectl
+++ b/scripts/updatectl
@@ -4,8 +4,8 @@
 
 # Get required settings from config.json.
 readarray -t config <\
-  <(jq '.aur_helper,
-        .terminal_cmd' "$PWD/config.json")
+  <(jaq '.aur_helper,
+         .terminal_cmd' "$PWD/config.json")
 
 # Remove double quotes.
 aur_helper="${config[0]//\"}"

--- a/scripts/weatherctl
+++ b/scripts/weatherctl
@@ -3,7 +3,7 @@
 # export RUST_BACKTRACE=full
 
 # Get weather location from config.json.
-: "$(jq '.weather_location' "$PWD/config.json")"
+: "$(jaq '.weather_location' "$PWD/config.json")"
 
 # Call wttr.in to retrieve local weather as PNG.
 curl wttr.in/"${_//\"}"_1nq.png\

--- a/scripts/workspacectl
+++ b/scripts/workspacectl
@@ -3,10 +3,10 @@
 # export RUST_BACKTRACE=full
 
 # Get active workspace.
-on="$(hyprctl monitors -j | jq '.[].activeWorkspace.id')"
+on="$(hyprctl monitors -j | jaq '.[].activeWorkspace.id')"
 
 # Get occupied workspaces ID(s).
-readarray -t w < <(hyprctl workspaces -j | jq '.[]?.id?')
+readarray -t w < <(hyprctl workspaces -j | jaq '.[]?.id?')
 
 # Create array and append the status of each workspace.
 ws=()


### PR DESCRIPTION
# [jaq](https://github.com/01mf02/jaq)

The following evaluation consists of several benchmarks that allow comparing the performance of [jaq](https://github.com/01mf02/jaq), [jq](https://github.com/stedolan/jq), and [gojq](https://github.com/itchyny/gojq).
The `empty` benchmark runs `n` times the filter `empty` with null input, serving to measure the startup time.
The `bf-fib` benchmark runs a Brainfuck interpreter written in jq, interpreting a Brainfuck script that produces `n` Fibonacci numbers.
The other benchmarks evaluate various filters with `n` as input.

Table: Evaluation results in seconds ("N/A" if more than 10 seconds).

| Benchmark    |       n | jaq-0.9.0 | jq-cff5336 | gojq-0.12.9 | jq-1.6 |
| ------------ | ------: | --------: | ---------: | ----------: | -----: |
| empty        |     512 |      0.83 |       1.25 |        0.96 |    N/A |
| bf-fib       |      13 |      0.92 |       1.30 |        2.52 |   3.16 |
| reverse      | 1048576 |      0.08 |       1.09 |        1.16 |   1.54 |
| sort         | 1048576 |      0.20 |       1.53 |        1.77 |   1.81 |
| add          | 1048576 |      0.96 |       1.06 |        2.51 |   1.69 |
| kv           |  131072 |      0.33 |       0.25 |        0.49 |   0.49 |
| kv-update    |  131072 |      0.38 |       0.67 |         N/A |    N/A |
| kv-entries   |  131072 |      1.23 |       1.29 |        2.23 |   2.50 |
| ex-implode   | 1048576 |      1.32 |       1.59 |        1.73 |   2.77 |
| reduce       | 1048576 |      1.60 |       1.34 |         N/A |   1.92 |
| tree-flatten |      17 |      0.71 |       0.54 |        0.03 |   1.95 |
| tree-update  |      17 |      0.47 |       1.43 |        4.58 |   2.73 |
| to-fromjson  |   65536 |      0.09 |       1.59 |        0.16 |   1.69 |

The results show that jaq is **faster** than jq-cff5336 on ten out of thirteen benchmarks and **faster** than jq 1.6 on *all* benchmarks.
gojq is **faster** than jaq only on one benchmark, namely "tree-flatten" (due to implementing the filter `flatten` natively instead of by definition).

https://github.com/01mf02/jaq#performance